### PR TITLE
Makes Interval lazy

### DIFF
--- a/src/test/scala/info/bethard/timenorm/formal/TypesTest.scala
+++ b/src/test/scala/info/bethard/timenorm/formal/TypesTest.scala
@@ -543,7 +543,7 @@ class TypesTest extends FunSuite {
     assert( nthUnitRI.end === LocalDateTime.of(2002, 3, 26, 0, 0, 0, 0))
 
     intercept [NotImplementedError] {
-      val nthFailure = Nth(interval, 5, frInterval)
+      val Interval(start, end) = Nth(interval, 5, frInterval)
     }
   }
 
@@ -553,7 +553,7 @@ class TypesTest extends FunSuite {
 
     //Multiple element result, ThisRepeatingIntervals should be used instead
     intercept [MatchError] {
-      ThisRepeatingInterval(interval,repeatingInterval)
+      val Interval(start, end) = ThisRepeatingInterval(interval,repeatingInterval)
     }
 
     //Interval: The Year of 2016


### PR DESCRIPTION
Makes `start` and `end` on Interval use `def` instead of `val`, and revises `Interval` implementations to use `lazy val`. The goal is to defer evaluation of things like `UnknownInterval`, which would otherwise cause anything that references them to throw an exception at construction time. Note that this required small changes in the test suite, because if neither `start` nor `end` is called, no exception will be produced.

I originally started down the path we had discussed for deferring this evaluation by making all the `Interval` operators into `Interval => Interval`s, but that ended up not really working out. For example, if `ThisRepeatingInterval` is an `Interval => Interval` and `TwoDigitYear` is an `Interval => Interval`, then it's not clear how to pass the `TwoDigitYear` as the `Interval` argument to `ThisRepeatingInterval` in a expression like "January of 89".